### PR TITLE
Refactor SMTP sending and add timeout handling

### DIFF
--- a/bot/env_config.py
+++ b/bot/env_config.py
@@ -66,3 +66,30 @@ def get_test_recipient_email():
     Author: baudoux.sebastien@gmail.com  | Version: 1.0 | 09/02/2025
     """
     return os.getenv("TEST_RECIPIENT_EMAIL")
+
+
+def get_email_smtp_host(default: str = "ssl0.ovh.net"):
+    """Récupère l'hôte SMTP (EMAIL_SMTP_HOST)."""
+    return os.getenv("EMAIL_SMTP_HOST", default)
+
+
+def get_email_smtp_port(default: int = 587):
+    """Récupère le port SMTP (EMAIL_SMTP_PORT)."""
+    value = os.getenv("EMAIL_SMTP_PORT")
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def get_email_smtp_timeout(default: float = 30.0):
+    """Récupère le timeout SMTP (EMAIL_SMTP_TIMEOUT)."""
+    value = os.getenv("EMAIL_SMTP_TIMEOUT")
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default

--- a/tests/test_email_cog.py
+++ b/tests/test_email_cog.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bot.discord_bot_commands import EmailCog
+
+
+class TestEmailCog(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot = MagicMock()
+        self.bot.messages_by_channel = {"important": {}, "general": {}}
+
+    async def test_test_send_daily_summary_cmd_timeout(self):
+        cog = EmailCog(self.bot)
+        ctx = MagicMock()
+        ctx.send = AsyncMock()
+
+        with patch("bot.discord_bot_commands.send_email", new=AsyncMock(side_effect=TimeoutError)), \
+             patch("bot.discord_bot_commands.save_messages_to_file") as mock_save, \
+             patch("bot.discord_bot_commands.logger") as mock_logger:
+            await cog.test_send_daily_summary_cmd(ctx)
+
+        ctx.send.assert_awaited_once_with(
+            "Échec de l'envoi du mail de test : délai d'attente dépassé."
+        )
+        mock_save.assert_not_called()
+        mock_logger.exception.assert_called_once()
+
+    async def test_test_send_daily_summary_cmd_oserror(self):
+        cog = EmailCog(self.bot)
+        ctx = MagicMock()
+        ctx.send = AsyncMock()
+
+        with patch(
+            "bot.discord_bot_commands.send_email",
+            new=AsyncMock(side_effect=OSError("network unreachable")),
+        ), patch("bot.discord_bot_commands.save_messages_to_file") as mock_save, patch(
+            "bot.discord_bot_commands.logger"
+        ) as mock_logger:
+            await cog.test_send_daily_summary_cmd(ctx)
+
+        ctx.send.assert_awaited_once_with(
+            "Échec de l'envoi du mail de test : erreur réseau lors de la connexion SMTP."
+        )
+        mock_save.assert_not_called()
+        mock_logger.exception.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mails.py
+++ b/tests/test_mails.py
@@ -10,9 +10,10 @@ Author: Ton Nom
 Version: 1.0 - 02/02/2025
 """
 
+import asyncio
 import unittest
 from unittest.mock import ANY
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from bot.mails_management import send_email
 
 class TestMailsManagement(unittest.TestCase):
@@ -29,10 +30,20 @@ class TestMailsManagement(unittest.TestCase):
         body = "Hello World"
 
         # Action
-        send_email(body, from_addr, password, to_addr)
-        
-        # Vérif que SMTP(...) a été appelé avec "smtp.ovh.com", 587
-        mock_smtp.assert_called_once_with("ssl0.ovh.net", 587)
+        asyncio.run(
+            send_email(
+                body,
+                from_addr,
+                password,
+                to_addr,
+                host="smtp.example.com",
+                port=2525,
+                timeout=12,
+            )
+        )
+
+        # Vérif que SMTP(...) a été appelé avec l'hôte/port donnés et timeout
+        mock_smtp.assert_called_once_with("smtp.example.com", 2525, timeout=12)
 
         # Récupérer l'instance "server" (celui qui subit server.starttls(), etc.)
         mock_server_instance = mock_smtp.return_value.__enter__.return_value


### PR DESCRIPTION
## Summary
- refactor `bot.mails_management.send_email` into an async wrapper around a synchronous helper that supports configurable SMTP host, port, and timeout via environment variables
- add SMTP configuration getters in `bot.env_config` and update email commands to await sending while logging timeout/network failures
- extend mail tests for the async sender and add coverage ensuring the test command reports clear messages when timeouts or network errors occur

## Testing
- `PYTHONPATH=. pytest` *(fails: existing tests import deprecated modules such as `bot._old_discord_bot_commands` and missing `summarize_message`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd37724060832cbe7bae99a3473b9e